### PR TITLE
changed price decimals to Option

### DIFF
--- a/src/coins/types/price.rs
+++ b/src/coins/types/price.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Price {
-    pub decimals: u8,
+    pub decimals: Option<u8>,
     pub symbol: String,
     pub price: f64,
     pub timestamp: u64,


### PR DESCRIPTION
As the `decimals` field is not returned when querying the `coingecko:ethereum` price, we can set it as an Option value to avoid the deserialize error.

curl -X 'GET' 'https://coins.llama.fi/prices/current/coingecko:ethereum' -H 'accept: application/json'
```json
{
  "coins": {
    "coingecko:ethereum": {
      "price": 2645.44,
      "symbol": "ETH",
      "timestamp": 1729353483,
      "confidence": 0.99
    }
  }
}
```


